### PR TITLE
Mouse Callbacks

### DIFF
--- a/examples/mouse_hook.cpp
+++ b/examples/mouse_hook.cpp
@@ -26,11 +26,11 @@ bool buttonCallback(Macro::Mouse::Button button, Macro::Mouse::ButtonState state
     return false;
 }
 
-bool scrollCallback(int delta) {
-    std::cout << "Scroll: " << delta << std::endl;
+bool scrollCallback(int delta, bool isHorizontal) {
+    std::cout << "Scroll " << (isHorizontal ? "horizontal": "vertical") << ": " << delta << std::endl;
 
-    // Block scrolling down.
-    if (delta < 0) {
+    // Block scrolling down vertically.
+    if (delta < 0 && !isHorizontal) {
         return true;
     }
 

--- a/examples/mouse_hook.cpp
+++ b/examples/mouse_hook.cpp
@@ -27,7 +27,8 @@ bool buttonCallback(Macro::Mouse::Button button, Macro::Mouse::ButtonState state
 }
 
 bool scrollCallback(int delta, bool isHorizontal) {
-    std::cout << "Scroll " << (isHorizontal ? "horizontal": "vertical") << ": " << delta << std::endl;
+    std::cout << "Scroll: " << delta << ", " << (isHorizontal ? "Horizontal" : "Vertical")
+              << std::endl;
 
     // Block scrolling down vertically.
     if (delta < 0 && !isHorizontal) {

--- a/include/macro/mouse.h
+++ b/include/macro/mouse.h
@@ -21,7 +21,7 @@ typedef std::map<Button, ButtonState> ButtonStateMap;
 
 typedef bool (*MoveCallback)(Point position);
 typedef bool (*ButtonCallback)(Button button, ButtonState state);
-typedef bool (*ScrollCallback)(int delta);
+typedef bool (*ScrollCallback)(int delta, bool horizontal);
 
 // Events
 void SetMoveCallback(MoveCallback callback);      // common

--- a/src/common/mouse.cpp
+++ b/src/common/mouse.cpp
@@ -23,13 +23,28 @@ std::string GetButtonName(Button button) {
 
 namespace Internal {
 
+ButtonStateMap buttonStates;
+
+bool MoveCb(Point position) {
+    // Reserved for future use.
+    (void)position;
+
+    return false;
+}
+
 bool ButtonCb(Button button, ButtonState state) {
     Internal::buttonStates[button] = state;
 
     return false;
 }
 
-ButtonStateMap buttonStates;
+bool ScrollCb(int delta, bool isHorizontal) {
+    // Reserved for future use.
+    (void)delta;
+    (void)isHorizontal;
+
+    return false;
+}
 
 MoveCallback moveCallback = nullptr;
 ButtonCallback buttonCallback = nullptr;

--- a/src/internal.h
+++ b/src/internal.h
@@ -31,9 +31,11 @@ extern KeyCallback keyCallback;
 namespace Mouse {
 namespace Internal {
 
-bool ButtonCb(Button button, ButtonState state);
-
 extern ButtonStateMap buttonStates;
+
+bool MoveCb(Point position);
+bool ButtonCb(Button button, ButtonState state);
+bool ScrollCb(int delta, bool isHorizontal);
 
 extern MoveCallback moveCallback;
 extern ButtonCallback buttonCallback;

--- a/src/win32/mouse_events.cpp
+++ b/src/win32/mouse_events.cpp
@@ -17,12 +17,25 @@ LRESULT CALLBACK LowLevelMouseProc(int nCode, WPARAM wParam, LPARAM lParam) {
         bool shouldBlock = false;
 
         if (wParam == WM_MOUSEMOVE) {
+            Point point{mouse->pt.x, mouse->pt.y};
+
+            if (Internal::MoveCb(point)) {
+                return 1;
+            }
+
             if (Internal::moveCallback != nullptr) {
-                shouldBlock = Internal::moveCallback({mouse->pt.x, mouse->pt.y});
+                shouldBlock = Internal::moveCallback(point);
             }
         } else if (wParam == WM_MOUSEWHEEL || wParam == WM_MOUSEHWHEEL) {
+            int delta = GET_WHEEL_DELTA_WPARAM(mouse->mouseData);
+            bool isHorizontal = (wParam == WM_MOUSEHWHEEL);
+
+            if (Internal::ScrollCb(delta, isHorizontal)) {
+                return 1;
+            }
+
             if (Internal::scrollCallback != nullptr) {
-                shouldBlock = Internal::scrollCallback(GET_WHEEL_DELTA_WPARAM(mouse->mouseData));
+                shouldBlock = Internal::scrollCallback(delta, isHorizontal);
             }
         } else {
             ButtonState state = (wParam == WM_LBUTTONDOWN || wParam == WM_RBUTTONDOWN ||


### PR DESCRIPTION
# Description

Implemented internal callbacks for mouse movements and scrolling.
Added an `isHorizontal` parameter to the scroll callback.

## Type of change

Please delete options that are not relevant.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation (non-breaking change that updates the documentation)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Updated the mouse hooks example.
Note: The mouse callbacks do not fire if a touchpad is used.