### PR TITLE
Add platform specific context object (internal change)

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,3 +1,5 @@
 set noparent
 
-filter=-build/c++11,-build/header_guard,-build/include_subdir,-build/include_order,-legal/copyright,-whitespace/line_length
+filter=-build/c++11,-build/header_guard,-build/include_subdir,-build/include_order
+filter=-legal/copyright
+filter=-whitespace/indent,-whitespace/line_length

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,7 @@ if (WIN32)
     message(STATUS "Detected platform: Windows")
     target_compile_definitions(macro PRIVATE _MACRO_WIN32)
     target_sources(macro PRIVATE
+        win32/context.cpp
         win32/keyboard.cpp win32/keyboard_events.cpp win32/key_map.cpp
         win32/mouse.cpp win32/mouse_events.cpp
         win32/misc.cpp
@@ -20,6 +21,7 @@ elseif (APPLE)
     message(STATUS "Detected platform: macOS")
     target_compile_definitions(macro PRIVATE _MACRO_COCOA)
     target_sources(macro PRIVATE
+        cocoa/context.cpp
         cocoa/keyboard.cpp cocoa/keyboard_events.cpp cocoa/key_map.cpp
         cocoa/mouse.cpp cocoa/mouse_events.cpp
         cocoa/misc.cpp
@@ -29,6 +31,7 @@ elseif (UNIX)
     find_package(X11 REQUIRED)
     target_compile_definitions(macro PRIVATE _MACRO_X11)
     target_sources(macro PRIVATE
+        x11/context.cpp
         x11/keyboard.cpp x11/keyboard_events.cpp x11/key_map.cpp
         x11/mouse.cpp x11/mouse_events.cpp
         x11/misc.cpp

--- a/src/cocoa/context.cpp
+++ b/src/cocoa/context.cpp
@@ -1,0 +1,10 @@
+#include <macro/mouse.h>
+
+#include "../internal.h"
+#include "../platform.h"
+
+namespace Macro {
+
+_Context ctx;
+
+}  // namespace Macro

--- a/src/internal.h
+++ b/src/internal.h
@@ -8,13 +8,25 @@
 #include "platform.h"
 
 namespace Macro {
-namespace Internal {
+
+class _Context {
 #if defined(_MACRO_WIN32)
+
 #elif defined(_MACRO_COCOA)
+
 #elif defined(_MACRO_X11)
-extern Display *display;
+  protected:
+    Display *display;
+
+  public:
+    Display *GetDisplay();
+
+    _Context();
+    ~_Context();
 #endif
-}  // namespace Internal
+};
+
+extern _Context ctx;
 
 namespace Keyboard {
 namespace Internal {

--- a/src/win32/context.cpp
+++ b/src/win32/context.cpp
@@ -1,0 +1,10 @@
+#include <macro/mouse.h>
+
+#include "../internal.h"
+#include "../platform.h"
+
+namespace Macro {
+
+_Context ctx;
+
+}  // namespace Macro

--- a/src/x11/context.cpp
+++ b/src/x11/context.cpp
@@ -1,0 +1,25 @@
+#include <macro/mouse.h>
+
+#include "../internal.h"
+#include "../platform.h"
+
+namespace Macro {
+
+Display *_Context::GetDisplay() {
+    if (display == nullptr) {
+        display = XOpenDisplay(NULL);
+    }
+    return display;
+}
+
+_Context::_Context() : display(nullptr) {}
+
+_Context::~_Context() {
+    if (display != nullptr) {
+        XCloseDisplay(display);
+    }
+}
+
+_Context ctx;
+
+}  // namespace Macro


### PR DESCRIPTION
# Description

Implemented a platform specific class `Macro::_Context` that has an instance defined as `Macro::ctx`.
This class stores the `Display` object for x11.

## Type of change

Please delete options that are not relevant.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation (non-breaking change that updates the documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

All tests and affected examples succeeded.