### PR TITLE
fix(mouse): scale MoveAbsolute coordinates on win32

### DIFF
--- a/examples/move.cpp
+++ b/examples/move.cpp
@@ -6,7 +6,7 @@ int main() {
     Macro::Misc::Sleep(2000);
     Macro::Mouse::MoveRelative(-300, -300);
     Macro::Misc::Sleep(1000);
-    Macro::Mouse::MoveAbsolute(30000, 30000);
+    Macro::Mouse::MoveAbsolute(200, 200);
 
     std::cout << "Done!" << std::endl;
     std::cin.get();

--- a/src/win32/mouse.cpp
+++ b/src/win32/mouse.cpp
@@ -14,6 +14,10 @@ Point GetPosition() {
 void MoveAbsolute(int x, int y) {
     // (0, 0) is the top left corner
     // (65535, 65535) is the bottom right corner
+
+    x = x * 65535 / GetDeviceCaps(GetDC(NULL), HORZRES);
+    y = y * 65535 / GetDeviceCaps(GetDC(NULL), VERTRES);
+
     INPUT input = {0};
     input.type = INPUT_MOUSE;
     input.mi.dx = x;

--- a/src/win32/mouse.cpp
+++ b/src/win32/mouse.cpp
@@ -17,8 +17,8 @@ void MoveAbsolute(int x, int y) {
     // (65535, 65535) is the bottom right corner
     INPUT input = {0};
     input.type = INPUT_MOUSE;
-    input.mi.dx = round(x * 65535 / GetDeviceCaps(GetDC(NULL), HORZRES));
-    input.mi.dy = round(y * 65535 / GetDeviceCaps(GetDC(NULL), VERTRES));
+    input.mi.dx = round(x * 65535.0 / GetDeviceCaps(GetDC(NULL), HORZRES));
+    input.mi.dy = round(y * 65535.0 / GetDeviceCaps(GetDC(NULL), VERTRES));
     input.mi.dwFlags = MOUSEEVENTF_MOVE | MOUSEEVENTF_ABSOLUTE;
     SendInput(1, &input, sizeof(INPUT));
 }

--- a/src/win32/mouse.cpp
+++ b/src/win32/mouse.cpp
@@ -1,3 +1,4 @@
+#include <cmath>
 #include <macro/mouse.h>
 
 #include "../platform.h"
@@ -14,14 +15,10 @@ Point GetPosition() {
 void MoveAbsolute(int x, int y) {
     // (0, 0) is the top left corner
     // (65535, 65535) is the bottom right corner
-
-    x = x * 65535 / GetDeviceCaps(GetDC(NULL), HORZRES);
-    y = y * 65535 / GetDeviceCaps(GetDC(NULL), VERTRES);
-
     INPUT input = {0};
     input.type = INPUT_MOUSE;
-    input.mi.dx = x;
-    input.mi.dy = y;
+    input.mi.dx = round(x * 65535 / GetDeviceCaps(GetDC(NULL), HORZRES));
+    input.mi.dy = round(y * 65535 / GetDeviceCaps(GetDC(NULL), VERTRES));
     input.mi.dwFlags = MOUSEEVENTF_MOVE | MOUSEEVENTF_ABSOLUTE;
     SendInput(1, &input, sizeof(INPUT));
 }

--- a/src/win32/mouse.cpp
+++ b/src/win32/mouse.cpp
@@ -1,7 +1,8 @@
-#include <cmath>
 #include <macro/mouse.h>
 
 #include "../platform.h"
+
+#include <cmath>
 
 namespace Macro {
 namespace Mouse {


### PR DESCRIPTION
# Description

For solved this bug
it's necessary to get the **ScreenSize.Width** and **ScreenSize.Height**
This post helped me to resolve the bug

[how-to-calculate-coordinates-to-move-the-mouse-cursor-programmatically](https://stackoverflow.com/questions/21965353/how-to-calculate-coordinates-to-move-the-mouse-cursor-programmatically
)

The scale formula is 
```
x = p.X * 65535 / GetDeviceCaps(GetDC(NULL), HORZRES)
y = p.Y * 65535 / GetDeviceCaps(GetDC(NULL), VERTRES)
```

## Type of change

- [ x ] Bugfix (non-breaking change which fixes an issue)

## How Has This Been Tested?

As you can see, it requires **scaling**, so we are likely to have a small rounding error of +1 or -1.
