### PR TITLE
chore(build): allow errors on x11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,8 +34,6 @@ jobs:
   build-macos:
     runs-on: macos-latest
 
-    continue-on-error: true # macOS support is still WIP
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -43,13 +41,14 @@ jobs:
           submodules: true
 
       - name: Install dependencies and build
+        continue-on-error: true
         run: |
           brew install doxygen
           mkdir build && cd build
           cmake ..
           cmake --build .
-          #cd test
-          #ctest -C Debug
+          cd test
+          ctest -C Debug
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
@@ -60,8 +59,6 @@ jobs:
 
   build-linux:
     runs-on: ubuntu-latest
-
-    continue-on-error: true # Linux support is still WIP
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,6 +67,7 @@ jobs:
           submodules: true
 
       - name: Install dependencies and build
+        continue-on-error: true
         run: |
           sudo apt-get install doxygen libx11-dev libxtst-dev -y
           mkdir build && cd build


### PR DESCRIPTION
# Description

Allow the GitHub actions build workflow to fail on x11.
Tests on x11 are failing due to them being executed in headless mode.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Build workflow succeeds on x11.