### PR TITLE
fix: set process DPI aware

### DIFF
--- a/src/internal.h
+++ b/src/internal.h
@@ -11,7 +11,9 @@ namespace Macro {
 
 class _Context {
 #if defined(_MACRO_WIN32)
-
+  public:
+    _Context();
+    ~_Context();
 #elif defined(_MACRO_COCOA)
 
 #elif defined(_MACRO_X11)

--- a/src/platform.h
+++ b/src/platform.h
@@ -3,6 +3,7 @@
 
 #if defined(_MACRO_WIN32)
     #include <windows.h>
+    #include <winuser.h>
 #elif defined(_MACRO_COCOA)
     #warning "Macro API for Cocoa is still WIP"
     #include <ApplicationServices/ApplicationServices.h>

--- a/src/win32/context.cpp
+++ b/src/win32/context.cpp
@@ -5,6 +5,13 @@
 
 namespace Macro {
 
+_Context::_Context() {
+    // Make our process DPI-aware.
+    SetProcessDPIAware();
+}
+
+_Context::~_Context() {}
+
 _Context ctx;
 
 }  // namespace Macro


### PR DESCRIPTION
# Description

Set the process to be DPI aware on win32 to correctly scale the position for `MoveCallback`.

Fixes #50 

## Type of change

Please delete options that are not relevant.

- [x] Bugfix (non-breaking change which fixes an issue)

## How Has This Been Tested?

The code to reproduce the bug behaves properly.