### PR TITLE
fix: scale mouse position to virtual screen

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,6 +15,23 @@ add_library(
 
 if(WIN32)
     message(STATUS "Detected platform: Windows")
+    if(${CMAKE_SYSTEM_VERSION} MATCHES "^10") # Windows 10
+        add_definitions(-D_WIN32_WINNT=0x0A00) # _WIN32_WINNT_WIN10
+    elseif(${CMAKE_SYSTEM_VERSION} MATCHES "^6.3") # Windows 8.1
+        add_definitions(-D_WIN32_WINNT=0x0603) # _WIN32_WINNT_WINBLUE
+    elseif(${CMAKE_SYSTEM_VERSION} MATCHES "^6.2") # Windows 8
+        add_definitions(-D_WIN32_WINNT=0x0602) # _WIN32_WINNT_WIN8
+    elseif(${CMAKE_SYSTEM_VERSION} MATCHES "^6.1") # Windows 7
+        add_definitions(-D_WIN32_WINNT=0x0601) # _WIN32_WINNT_WIN7
+    elseif(${CMAKE_SYSTEM_VERSION} MATCHES "^6.0") # Windows Vista
+        add_definitions(-D_WIN32_WINNT=0x0600) # _WIN32_WINNT_VISTA
+    elseif(${CMAKE_SYSTEM_VERSION} MATCHES "^5.2") # Windows Server 2003
+        add_definitions(-D_WIN32_WINNT=0x0502) # _WIN32_WINNT_WS03
+    elseif(${CMAKE_SYSTEM_VERSION} MATCHES "^5.1") # Windows XP
+        add_definitions(-D_WIN32_WINNT=0x0501) # _WIN32_WINNT_WINXP
+    elseif(${CMAKE_SYSTEM_VERSION} MATCHES "^5.0") # Windows 2000
+        add_definitions(-D_WIN32_WINNT=0x0500) # _WIN32_WINNT_WIN2K
+    endif()
     target_compile_definitions(macro PRIVATE _MACRO_WIN32)
     target_sources(
         macro
@@ -69,7 +86,7 @@ set_target_properties(
 )
 
 if(WIN32)
-    # empty
+    target_link_libraries(macro PRIVATE shcore)
 elseif(APPLE)
     target_link_libraries(macro PRIVATE Threads::Threads)
 elseif(UNIX)

--- a/src/platform.h
+++ b/src/platform.h
@@ -3,6 +3,7 @@
 
 #if defined(_MACRO_WIN32)
     #include <windows.h>
+    #include <shellscalingapi.h>
 #elif defined(_MACRO_COCOA)
     #warning "Macro API for Cocoa is still WIP"
     #include <ApplicationServices/ApplicationServices.h>

--- a/src/platform.h
+++ b/src/platform.h
@@ -2,8 +2,8 @@
 #define _platform_h_
 
 #if defined(_MACRO_WIN32)
-    #include <windows.h>
     #include <shellscalingapi.h>
+    #include <windows.h>
 #elif defined(_MACRO_COCOA)
     #warning "Macro API for Cocoa is still WIP"
     #include <ApplicationServices/ApplicationServices.h>

--- a/tools/clang_format_all.py
+++ b/tools/clang_format_all.py
@@ -2,7 +2,7 @@ import pathlib
 import subprocess
 
 clang_format = "clang-format"
-exclude = ["../build", "../test/doctest.h"]
+exclude = ["../build", "../doc", "../test/doctest.h"]
 extensions = [".cpp", ".hpp", ".h", ".c", ".cc", ".hh", ".cxx", ".hxx"]
 
 


### PR DESCRIPTION
# Description

Scale the mouse position to the virtual screen by the DPI of the monitor.
The `MoveCallback` position parameter is now DPI aware.

Fixes #50 

## Type of change

Please delete options that are not relevant.

- [x] Bugfix (non-breaking change which fixes an issue)

## How Has This Been Tested?

The code to reproduce the bug behaves properly.

`MoveCallback` is now DPI aware. :heavy_check_mark:
`GetPosition` is DPI aware. :heavy_check_mark:
`MoveAbsolute` is DPI aware. :heavy_check_mark:
`MoveRelative` is DPI aware. :heavy_check_mark:
