### PR TITLE
 test(keyboard): add unit test for MapFromChar

### DIFF
--- a/test/keyboard/entry.h
+++ b/test/keyboard/entry.h
@@ -1,1 +1,2 @@
 #include "key_conversion.h"
+#include "map_from_char.h"

--- a/test/keyboard/map_from_char.h
+++ b/test/keyboard/map_from_char.h
@@ -2,7 +2,7 @@
 #include <map>
 
 TEST_CASE("[keyboard] map from char") {
-    // lowercase
+    INFO("Lowercase");
     for (char c = 'a'; c <= 'z'; ++c) {
         INFO("Char: ", c);
         Macro::Keyboard::Combo combo = Macro::Keyboard::MapFromChar(c);
@@ -12,7 +12,7 @@ TEST_CASE("[keyboard] map from char") {
         CHECK_EQ(combo.alt, false);
     }
 
-    // uppercase
+    INFO("Uppercase");
     for (char c = 'A'; c <= 'Z'; ++c) {
         INFO("Char: ", c);
         Macro::Keyboard::Combo combo = Macro::Keyboard::MapFromChar(c);
@@ -22,7 +22,7 @@ TEST_CASE("[keyboard] map from char") {
         CHECK_EQ(combo.alt, false);
     }
 
-    // numbers
+    INFO("Numbers");
     for (char c = '0'; c <= '9'; ++c) {
         INFO("Char: ", c);
         Macro::Keyboard::Combo combo = Macro::Keyboard::MapFromChar(c);
@@ -32,7 +32,7 @@ TEST_CASE("[keyboard] map from char") {
         CHECK_EQ(combo.alt, false);
     }
 
-    // symbols (unshifted)
+    INFO("Symbols (unshifted)");
     std::map<char, Macro::Keyboard::Key> unshifted_symbols = {
         // clang-format off
         {';', Macro::Keyboard::Key::COLON},
@@ -59,7 +59,7 @@ TEST_CASE("[keyboard] map from char") {
         CHECK_EQ(combo.alt, false);
     }
 
-    // symbols (shifted)
+    INFO("Symbols (shifted)");
     std::map<char, Macro::Keyboard::Key> shifted_symbols = {
         // clang-format off
         {'!', Macro::Keyboard::Key::ONE},
@@ -96,7 +96,7 @@ TEST_CASE("[keyboard] map from char") {
         CHECK_EQ(combo.alt, false);
     }
 
-    // special keys
+    INFO("Special keys");
     std::map<char, Macro::Keyboard::Key> special_keys = {
         // clang-format off
         {'\b', Macro::Keyboard::Key::BACKSPACE},

--- a/test/keyboard/map_from_char.h
+++ b/test/keyboard/map_from_char.h
@@ -1,5 +1,5 @@
-#include <cctype>
 #include <map>
+#include <string>
 
 TEST_CASE("[keyboard] map from char") {
     INFO("Lowercase");

--- a/test/keyboard/map_from_char.h
+++ b/test/keyboard/map_from_char.h
@@ -1,34 +1,29 @@
 #include <map>
 
+#define CHECK_KEY_COMBO(ch, expected_key, expected_shift, expected_ctrl, expected_alt)             \
+    {                                                                                              \
+        INFO("Char: ", ch);                                                                        \
+        Macro::Keyboard::Combo combo = Macro::Keyboard::MapFromChar(ch);                           \
+        CHECK_EQ(combo.key, expected_key);                                                         \
+        CHECK_EQ(combo.shift, expected_shift);                                                     \
+        CHECK_EQ(combo.ctrl, expected_ctrl);                                                       \
+        CHECK_EQ(combo.alt, expected_alt);                                                         \
+    }
+
 TEST_CASE("[keyboard] map from char") {
     INFO("Lowercase");
     for (char c = 'a'; c <= 'z'; ++c) {
-        INFO("Char: ", c);
-        Macro::Keyboard::Combo combo = Macro::Keyboard::MapFromChar(c);
-        CHECK_EQ(combo.key - Macro::Keyboard::Key::A, c - 'a');
-        CHECK_EQ(combo.shift, false);
-        CHECK_EQ(combo.ctrl, false);
-        CHECK_EQ(combo.alt, false);
+        CHECK_KEY_COMBO(c, c - 'a' + Macro::Keyboard::Key::A, false, false, false);
     }
 
     INFO("Uppercase");
     for (char c = 'A'; c <= 'Z'; ++c) {
-        INFO("Char: ", c);
-        Macro::Keyboard::Combo combo = Macro::Keyboard::MapFromChar(c);
-        CHECK_EQ(combo.key - Macro::Keyboard::Key::A, c - 'A');
-        CHECK_EQ(combo.shift, true);
-        CHECK_EQ(combo.ctrl, false);
-        CHECK_EQ(combo.alt, false);
+        CHECK_KEY_COMBO(c, c - 'A' + Macro::Keyboard::Key::A, true, false, false);
     }
 
     INFO("Numbers");
     for (char c = '0'; c <= '9'; ++c) {
-        INFO("Char: ", c);
-        Macro::Keyboard::Combo combo = Macro::Keyboard::MapFromChar(c);
-        CHECK_EQ(combo.key - Macro::Keyboard::Key::ZERO, c - '0');
-        CHECK_EQ(combo.shift, false);
-        CHECK_EQ(combo.ctrl, false);
-        CHECK_EQ(combo.alt, false);
+        CHECK_KEY_COMBO(c, c - '0' + Macro::Keyboard::Key::ZERO, false, false, false);
     }
 
     INFO("Symbols (unshifted)");
@@ -50,12 +45,7 @@ TEST_CASE("[keyboard] map from char") {
     for (auto &pair : unshifted_symbols) {
         char c = pair.first;
         Macro::Keyboard::Key key = pair.second;
-        INFO("Char: ", c);
-        Macro::Keyboard::Combo combo = Macro::Keyboard::MapFromChar(c);
-        CHECK_EQ(combo.key, key);
-        CHECK_EQ(combo.shift, false);
-        CHECK_EQ(combo.ctrl, false);
-        CHECK_EQ(combo.alt, false);
+        CHECK_KEY_COMBO(c, key, false, false, false);
     }
 
     INFO("Symbols (shifted)");
@@ -87,12 +77,7 @@ TEST_CASE("[keyboard] map from char") {
     for (auto &pair : shifted_symbols) {
         char c = pair.first;
         Macro::Keyboard::Key key = pair.second;
-        INFO("Char: ", c);
-        Macro::Keyboard::Combo combo = Macro::Keyboard::MapFromChar(c);
-        CHECK_EQ(combo.key, key);
-        CHECK_EQ(combo.shift, true);
-        CHECK_EQ(combo.ctrl, false);
-        CHECK_EQ(combo.alt, false);
+        CHECK_KEY_COMBO(c, key, true, false, false);
     }
 
     INFO("Special keys");
@@ -108,11 +93,8 @@ TEST_CASE("[keyboard] map from char") {
     for (auto &pair : special_keys) {
         char c = pair.first;
         Macro::Keyboard::Key key = pair.second;
-        INFO("Char: ", c);
-        Macro::Keyboard::Combo combo = Macro::Keyboard::MapFromChar(c);
-        CHECK_EQ(combo.key, key);
-        CHECK_EQ(combo.shift, false);
-        CHECK_EQ(combo.ctrl, false);
-        CHECK_EQ(combo.alt, false);
+        CHECK_KEY_COMBO(c, key, false, false, false);
     }
 }
+
+#undef CHECK_KEY_COMBO

--- a/test/keyboard/map_from_char.h
+++ b/test/keyboard/map_from_char.h
@@ -1,0 +1,119 @@
+#include <cctype>
+#include <map>
+
+TEST_CASE("[keyboard] map from char") {
+    // lowercase
+    for (char c = 'a'; c <= 'z'; ++c) {
+        INFO("Char: ", c);
+        Macro::Keyboard::Combo combo = Macro::Keyboard::MapFromChar(c);
+        CHECK_EQ(Macro::Keyboard::GetKeyName(combo.key), std::string(1, c - 'a' + 'A'));
+        CHECK_EQ(combo.shift, false);
+        CHECK_EQ(combo.ctrl, false);
+        CHECK_EQ(combo.alt, false);
+    }
+
+    // uppercase
+    for (char c = 'A'; c <= 'Z'; ++c) {
+        INFO("Char: ", c);
+        Macro::Keyboard::Combo combo = Macro::Keyboard::MapFromChar(c);
+        CHECK_EQ(Macro::Keyboard::GetKeyName(combo.key), std::string(1, c));
+        CHECK_EQ(combo.shift, true);
+        CHECK_EQ(combo.ctrl, false);
+        CHECK_EQ(combo.alt, false);
+    }
+
+    // numbers
+    for (char c = '0'; c <= '9'; ++c) {
+        INFO("Char: ", c);
+        Macro::Keyboard::Combo combo = Macro::Keyboard::MapFromChar(c);
+        CHECK_EQ(combo.key - Macro::Keyboard::Key::ZERO, c - '0');
+        CHECK_EQ(combo.shift, false);
+        CHECK_EQ(combo.ctrl, false);
+        CHECK_EQ(combo.alt, false);
+    }
+
+    // symbols (unshifted)
+    std::map<char, Macro::Keyboard::Key> unshifted_symbols = {
+        // clang-format off
+        {';', Macro::Keyboard::Key::COLON},
+        {'=', Macro::Keyboard::Key::PLUS},
+        {',', Macro::Keyboard::Key::COMMA},
+        {'-', Macro::Keyboard::Key::MINUS},
+        {'.', Macro::Keyboard::Key::PERIOD},
+        {'/', Macro::Keyboard::Key::SLASH},
+        {'`', Macro::Keyboard::Key::TILDE},
+        {'[', Macro::Keyboard::Key::LEFT_BRACKET},
+        {'\\', Macro::Keyboard::Key::BACKSLASH},
+        {']', Macro::Keyboard::Key::RIGHT_BRACKET},
+        {'\'', Macro::Keyboard::Key::QUOTE},
+        // clang-format on
+    };
+    for (auto &pair : unshifted_symbols) {
+        char c = pair.first;
+        Macro::Keyboard::Key key = pair.second;
+        INFO("Char: ", c);
+        Macro::Keyboard::Combo combo = Macro::Keyboard::MapFromChar(c);
+        CHECK_EQ(combo.key, key);
+        CHECK_EQ(combo.shift, false);
+        CHECK_EQ(combo.ctrl, false);
+        CHECK_EQ(combo.alt, false);
+    }
+
+    // symbols (shifted)
+    std::map<char, Macro::Keyboard::Key> shifted_symbols = {
+        // clang-format off
+        {'!', Macro::Keyboard::Key::ONE},
+        {'@', Macro::Keyboard::Key::TWO},
+        {'#', Macro::Keyboard::Key::THREE},
+        {'$', Macro::Keyboard::Key::FOUR},
+        {'%', Macro::Keyboard::Key::FIVE},
+        {'^', Macro::Keyboard::Key::SIX},
+        {'&', Macro::Keyboard::Key::SEVEN},
+        {'*', Macro::Keyboard::Key::EIGHT},
+        {'(', Macro::Keyboard::Key::NINE},
+        {')', Macro::Keyboard::Key::ZERO},
+        {':', Macro::Keyboard::Key::COLON},
+        {'+', Macro::Keyboard::Key::PLUS},
+        {'<', Macro::Keyboard::Key::COMMA},
+        {'_', Macro::Keyboard::Key::MINUS},
+        {'>', Macro::Keyboard::Key::PERIOD},
+        {'?', Macro::Keyboard::Key::SLASH},
+        {'~', Macro::Keyboard::Key::TILDE},
+        {'{', Macro::Keyboard::Key::LEFT_BRACKET},
+        {'|', Macro::Keyboard::Key::BACKSLASH},
+        {'}', Macro::Keyboard::Key::RIGHT_BRACKET},
+        {'"', Macro::Keyboard::Key::QUOTE},
+        // clang-format on
+    };
+    for (auto &pair : shifted_symbols) {
+        char c = pair.first;
+        Macro::Keyboard::Key key = pair.second;
+        INFO("Char: ", c);
+        Macro::Keyboard::Combo combo = Macro::Keyboard::MapFromChar(c);
+        CHECK_EQ(combo.key, key);
+        CHECK_EQ(combo.shift, true);
+        CHECK_EQ(combo.ctrl, false);
+        CHECK_EQ(combo.alt, false);
+    }
+
+    // special keys
+    std::map<char, Macro::Keyboard::Key> special_keys = {
+        // clang-format off
+        {'\b', Macro::Keyboard::Key::BACKSPACE},
+        {'\t', Macro::Keyboard::Key::TAB},
+        {'\r', Macro::Keyboard::Key::ENTER},
+        {' ', Macro::Keyboard::Key::SPACE},
+        {'\e', Macro::Keyboard::Key::ESCAPE},
+        // clang-format on
+    };
+    for (auto &pair : special_keys) {
+        char c = pair.first;
+        Macro::Keyboard::Key key = pair.second;
+        INFO("Char: ", c);
+        Macro::Keyboard::Combo combo = Macro::Keyboard::MapFromChar(c);
+        CHECK_EQ(combo.key, key);
+        CHECK_EQ(combo.shift, false);
+        CHECK_EQ(combo.ctrl, false);
+        CHECK_EQ(combo.alt, false);
+    }
+}

--- a/test/keyboard/map_from_char.h
+++ b/test/keyboard/map_from_char.h
@@ -1,12 +1,11 @@
 #include <map>
-#include <string>
 
 TEST_CASE("[keyboard] map from char") {
     INFO("Lowercase");
     for (char c = 'a'; c <= 'z'; ++c) {
         INFO("Char: ", c);
         Macro::Keyboard::Combo combo = Macro::Keyboard::MapFromChar(c);
-        CHECK_EQ(Macro::Keyboard::GetKeyName(combo.key), std::string(1, c - 'a' + 'A'));
+        CHECK_EQ(combo.key - Macro::Keyboard::Key::A, c - 'a');
         CHECK_EQ(combo.shift, false);
         CHECK_EQ(combo.ctrl, false);
         CHECK_EQ(combo.alt, false);
@@ -16,7 +15,7 @@ TEST_CASE("[keyboard] map from char") {
     for (char c = 'A'; c <= 'Z'; ++c) {
         INFO("Char: ", c);
         Macro::Keyboard::Combo combo = Macro::Keyboard::MapFromChar(c);
-        CHECK_EQ(Macro::Keyboard::GetKeyName(combo.key), std::string(1, c));
+        CHECK_EQ(combo.key - Macro::Keyboard::Key::A, c - 'A');
         CHECK_EQ(combo.shift, true);
         CHECK_EQ(combo.ctrl, false);
         CHECK_EQ(combo.alt, false);

--- a/test/keyboard/map_from_char.h
+++ b/test/keyboard/map_from_char.h
@@ -87,7 +87,7 @@ TEST_CASE("[keyboard] map from char") {
         {'\t', Macro::Keyboard::Key::TAB},
         {'\r', Macro::Keyboard::Key::ENTER},
         {' ', Macro::Keyboard::Key::SPACE},
-        {'\e', Macro::Keyboard::Key::ESCAPE},
+        {'\x1B', Macro::Keyboard::Key::ESCAPE},
         // clang-format on
     };
     for (auto &pair : special_keys) {


### PR DESCRIPTION
# Description

Add unit test for `Macro::Keyboard::MapFromChar`. This test checks lowercase, uppercase, numbers, symbols, and special keys. Only the key and shift are checked at the moment, but in the future, the other modifiers should be checked as well.

## Type of change

Unit test.